### PR TITLE
Feature: Allow setting a logging level + detect backend logging level

### DIFF
--- a/lib/ConsoleLogger.ts
+++ b/lib/ConsoleLogger.ts
@@ -9,27 +9,29 @@ export class ConsoleLogger implements ILogger {
     }
 
     private formatMessage(message: string, level: LogLevel, context: any): string {
-        let msg = '[' + level + ']'
+        let msg = '[' + LogLevel[level].toUpperCase() + ']'
         if (context && context.app) {
             msg += ' ' + context.app + ': '
         }
         return msg + message
     }
 
-    log(level: number, message: string, context: object) {
+    log(level: LogLevel, message: string, context: object) {
+	if (level < this.context?.level) return;
         switch (level) {
-            case 0:
+            case LogLevel.Debug:
                 console.debug(this.formatMessage(message, LogLevel.Debug, context), context)
                 break
-            case 1:
+            case LogLevel.Info:
                 console.info(this.formatMessage(message, LogLevel.Info, context), context)
                 break
-            case 2:
+            case LogLevel.Warn:
                 console.warn(this.formatMessage(message, LogLevel.Warn, context), context)
                 break
-            case 3:
+            case LogLevel.Error:
                 console.error(this.formatMessage(message, LogLevel.Error, context), context)
                 break
+            case LogLevel.Fatal:
             default:
                 console.error(this.formatMessage(message, LogLevel.Fatal, context), context)
                 break
@@ -37,23 +39,23 @@ export class ConsoleLogger implements ILogger {
     }
 
     debug(message: string, context?: object): void {
-        this.log(0, message, Object.assign({}, this.context, context))
+        this.log(LogLevel.Debug, message, Object.assign({}, this.context, context))
     }
 
     info(message: string, context?: object): void {
-        this.log(1, message, Object.assign({}, this.context, context))
+        this.log(LogLevel.Info, message, Object.assign({}, this.context, context))
     }
 
     warn(message: string, context?: object): void {
-        this.log(2, message, Object.assign({}, this.context, context))
+        this.log(LogLevel.Warn, message, Object.assign({}, this.context, context))
     }
 
     error(message: string, context?: object): void {
-        this.log(3, message, Object.assign({}, this.context, context))
+        this.log(LogLevel.Error, message, Object.assign({}, this.context, context))
     }
 
     fatal(message: string, context?: object): void {
-        this.log(4, message, Object.assign({}, this.context, context))
+        this.log(LogLevel.Fatal, message, Object.assign({}, this.context, context))
     }
 
 }

--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -1,6 +1,9 @@
-import { getCurrentUser } from '@nextcloud/auth'
+/// <reference types="@nextcloud/typings" />
 
+import { getCurrentUser } from '@nextcloud/auth'
 import { ILogger, ILoggerFactory, LogLevel } from './contracts'
+
+declare var OC: Nextcloud.v22.OC | Nextcloud.v23.OC | Nextcloud.v24.OC;
 
 export class LoggerBuilder {
 
@@ -11,6 +14,12 @@ export class LoggerBuilder {
     constructor(factory: ILoggerFactory) {
         this.context = {}
         this.factory = factory
+        // Up to, including, nextcloud 24 the loglevel was not exposed
+        this.context.level = OC.config?.loglevel !== undefined ? OC.config.loglevel : LogLevel.Warn
+        // Override loglevel if we are in debug mode
+        if (OC.debug) {
+            this.context.level = LogLevel.Debug
+        }
     }
 
     setApp(appId: string): LoggerBuilder {

--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -1,6 +1,6 @@
 import { getCurrentUser } from '@nextcloud/auth'
 
-import { ILogger, ILoggerFactory } from './contracts'
+import { ILogger, ILoggerFactory, LogLevel } from './contracts'
 
 export class LoggerBuilder {
 
@@ -15,6 +15,11 @@ export class LoggerBuilder {
 
     setApp(appId: string): LoggerBuilder {
         this.context.app = appId
+        return this
+    }
+
+    setLogLevel(level: LogLevel) {
+        this.context.level = level
         return this
     }
 

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -1,9 +1,9 @@
 export enum LogLevel {
-    Debug = 'DEBUG',
-    Info = 'INFO',
-    Warn = 'WARN',
-    Error = 'ERROR',
-    Fatal = 'FATAL',
+    Debug = 0,
+    Info  = 1,
+    Warn  = 2,
+    Error = 3,
+    Fatal = 4,
 }
 
 export interface ILogger {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-env": "^7.8.7",
     "@babel/preset-typescript": "^7.8.3",
     "@nextcloud/browserslist-config": "^2.0.0",
+    "@nextcloud/typings": "1.4.3",
     "typedoc": "^0.22.4",
     "typescript": "^4.0.2"
   },


### PR DESCRIPTION
This PR consists of two commits, the first adds a feature to set a logging level (everything below this will be discarded).
It should result in a much cleaner console log and also improve the overall performance as even with closed console logging is quite slow with all major browsers (~10'000 times slower, with opened console ~100'000 times slower than discarding).

The second commit allow parsing the backend logging level, implementing #141.
The backend logging level is currently not exposed, but there is a submit request, hopefully merged for nextcloud 25, for backwards compatibility the exposed `OC.debug` is used.

This slightly changes the API, the usage of the enum instead of `number` should not break any existing code.
But now by default `debug` messages are not shown unless the logging level is set manually or the backend is configured to do so, as the default logging level of the backend is `WARN`. But I think this is more an improvement than a drawback.