### PR TITLE
Do not require the `OC` variable to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.x.y - tbd
+### Changed
+- More robust agains library loading order problems
+
 ## 2.2.0 – 2022-06-27
 ### Added
 - Respect server log level and debug mode settings

--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -15,9 +15,9 @@ export class LoggerBuilder {
         this.context = {}
         this.factory = factory
         // Up to, including, nextcloud 24 the loglevel was not exposed
-        this.context.level = OC.config?.loglevel !== undefined ? OC.config.loglevel : LogLevel.Warn
+        this.context.level = OC?.config?.loglevel !== undefined ? OC.config.loglevel : LogLevel.Warn
         // Override loglevel if we are in debug mode
-        if (OC.debug) {
+        if (OC?.debug) {
             this.context.level = LogLevel.Debug
         }
     }


### PR DESCRIPTION
Fixes #361

This makes the library more robust against loading order problems
and reduces problems with testing setups.