### PR TITLE
Fix node scripts for building and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Right now the package uses `window.console` as log appender and produces the fol
 [WARN] mail: it's just a warning, carry on { app: 'mail', uid: 'christoph' }
 ```
 
+The logger tries to detect the server configured logging level by default,
+which can be configured using the `loglevel_frontend` option in the `config.php`.
+In case no logging level was configured or detection failed, the logger will fallback to the *warning* level.
+
+If the server is set to the debug mode the configured logging level will be set to the *debug* level.
+
+Any message with a lower level than the configured will not be printed on the console.
+
+You can override the logging level in both cases by setting it manually using the `setLogLevel` function
+when building the logger.
+
 ## Contributing
 
 This repository is maintained using [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/lib/ConsoleLogger.ts
+++ b/lib/ConsoleLogger.ts
@@ -17,7 +17,8 @@ export class ConsoleLogger implements ILogger {
     }
 
     log(level: LogLevel, message: string, context: object) {
-	if (level < this.context?.level) return;
+        if (level < this.context?.level) return;
+
         switch (level) {
             case LogLevel.Debug:
                 console.debug(this.formatMessage(message, LogLevel.Debug, context), context)

--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -22,21 +22,27 @@ export class LoggerBuilder {
         }
     }
 
+    /** Set the app name within the logging context */
     setApp(appId: string): LoggerBuilder {
         this.context.app = appId
         return this
     }
 
+    /** Set the logging level within the logging context */
     setLogLevel(level: LogLevel) {
         this.context.level = level
         return this
     }
 
+    /** Set the user id within the logging context
+     * @see {@link detectUser}
+    */
     setUid(uid: string): LoggerBuilder {
         this.context.uid = uid
         return this
     }
 
+    /** Detect the currently logged in user and set the user id within the logging context */
     detectUser(): LoggerBuilder {
         const user = getCurrentUser()
         if (user !== null) {
@@ -46,6 +52,7 @@ export class LoggerBuilder {
         return this
     }
 
+    /** Build a logger using the logging context and factory */
     build(): ILogger {
         return this.factory(this.context)
     }

--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -5,6 +5,9 @@ import { ILogger, ILoggerFactory, LogLevel } from './contracts'
 
 declare var OC: Nextcloud.v22.OC | Nextcloud.v23.OC | Nextcloud.v24.OC;
 
+/**
+ * @notExported
+ */
 export class LoggerBuilder {
 
     private context: any

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,3 +15,6 @@ export function getLoggerBuilder(): LoggerBuilder {
 export function getLogger(): ILogger {
     return getLoggerBuilder().build()
 }
+
+export { type LoggerBuilder }
+export { LogLevel, type ILogger, type ILoggerFactory } from './contracts'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "@babel/preset-typescript": "^7.8.3",
         "@nextcloud/browserslist-config": "^2.0.0",
         "@nextcloud/typings": "1.5.0",
-        "typedoc": "^0.23.3",
-        "typescript": "^4.0.2"
+        "typedoc": "^0.23.24",
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": "^16.0.0",
@@ -2206,20 +2206,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2403,9 +2389,9 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "node_modules/lodash.debounce": {
@@ -2445,9 +2431,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
-      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -2665,14 +2651,14 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
+      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
       "dev": true,
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/slash": {
@@ -2731,15 +2717,15 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.23",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
-      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "version": "0.23.24",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
+      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.4",
-        "minimatch": "^5.1.1",
-        "shiki": "^0.11.1"
+        "marked": "^4.2.5",
+        "minimatch": "^5.1.2",
+        "shiki": "^0.12.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -2761,9 +2747,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2852,15 +2838,15 @@
       }
     },
     "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "node_modules/vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "node_modules/wrappy": {
@@ -4414,13 +4400,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4556,9 +4535,9 @@
       "dev": true
     },
     "jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "lodash.debounce": {
@@ -4592,9 +4571,9 @@
       }
     },
     "marked": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
-      "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true
     },
     "minimatch": {
@@ -4766,14 +4745,14 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
+      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
       "dev": true,
       "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "slash": {
@@ -4814,15 +4793,15 @@
       }
     },
     "typedoc": {
-      "version": "0.23.23",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
-      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "version": "0.23.24",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
+      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.4",
-        "minimatch": "^5.1.1",
-        "shiki": "^0.11.1"
+        "marked": "^4.2.5",
+        "minimatch": "^5.1.2",
+        "shiki": "^0.12.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -4835,9 +4814,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -4890,15 +4869,15 @@
       }
     },
     "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -d && babel ./lib --out-dir dist --extensions '.ts,.tsx' --source-maps",
-    "build:doc": "typedoc --out dist/doc ./lib && touch dist/doc/.nojekyll",
+    "build:doc": "typedoc",
     "check-types": "tsc --noEmit",
     "dev": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --watch",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --source-maps",
-    "build:doc": "typedoc --toc getLogger,getLoggerBuilder,ILogger,LoggerBuilder --excludeNotExported --mode file --out dist/doc lib/index.ts && touch dist/doc/.nojekyll",
-    "check-types": "tsc",
+    "build": "tsc -d && babel ./lib --out-dir dist --extensions '.ts,.tsx' --source-maps",
+    "build:doc": "typedoc --out dist/doc ./lib && touch dist/doc/.nojekyll",
+    "check-types": "tsc --noEmit",
     "dev": "babel ./lib --out-dir dist --extensions '.ts,.tsx' --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -31,8 +31,8 @@
     "@babel/preset-typescript": "^7.8.3",
     "@nextcloud/browserslist-config": "^2.0.0",
     "@nextcloud/typings": "1.5.0",
-    "typedoc": "^0.23.3",
-    "typescript": "^4.0.2"
+    "typedoc": "^0.23.24",
+    "typescript": "^4.9.4"
   },
   "browserslist": [
     "extends @nextcloud/browserslist-config"

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://typedoc.org/schema.json",
+    "entryPoints": ["./lib/index.ts"],
+    "out": "dist/doc",
+    "githubPages": true,
+    "navigationLinks": {
+        "GitHub": "https://github.com/nextcloud/nextcloud-logger"
+    }
+}


### PR DESCRIPTION
Ensure the typescript declaration files are build when using the
node script `build`.

Fixed the `build:doc` script as typedoc dropped some commandline flags.
Also typedoc `0.23.x` requires typescript 4.6+

Fixed the documentation by exporting all necessary objects in the entry point
and added some documentation for setting the logging level.