### PR TITLE
Do not use optional chaining on a potentially undeclared root object

### DIFF
--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -15,9 +15,9 @@ export class LoggerBuilder {
         this.context = {}
         this.factory = factory
         // Up to, including, nextcloud 24 the loglevel was not exposed
-        this.context.level = OC?.config?.loglevel !== undefined ? OC.config.loglevel : LogLevel.Warn
+        this.context.level = (window.hasOwnProperty('OC') && OC?.config?.loglevel !== undefined) ? OC.config.loglevel : LogLevel.Warn
         // Override loglevel if we are in debug mode
-        if (OC?.debug) {
+        if (window.hasOwnProperty('OC') && OC?.debug) {
             this.context.level = LogLevel.Debug
         }
     }


### PR DESCRIPTION
Follow up to #362

The global `OC` variable may be undefined depending on the initialization order, so optional chaining (`OC?.config` and `OC?.debug`) was added to prevent accessing fields on an undefined variable.
    
However, `OC` could be not only undefined, but also undeclared. [Optional chaining can not be used on an undeclared root object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), so it needs to be explicitly guarded against that to prevent a `ReferenceError` to be thrown.

The `ReferenceError` can be seen in the PDF viewer since [the update of nextcloud/logger to 2.2.1](https://github.com/nextcloud/files_pdfviewer/pull/626) (note that [it also happened after the update to 2.2.0](https://github.com/nextcloud/files_pdfviewer/issues/624)).