### PR TITLE
chore: Move nightly bumps to Wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-    day: saturday
+    day: wednesday
     time: "03:00"
-    timezone: Europe/Paris
+    timezone: Europe/Berlin
   open-pull-requests-limit: 10


### PR DESCRIPTION
This distributes the bumps across the work week.