### PR TITLE
Add CI for deploying documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,32 @@
+name: Deploy documentation
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
+      - name: Install dependencies & build
+        run: |
+          npm ci
+          npm run build:doc
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist/doc
+          branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # @nextcloud/logger
 
+[![npm](https://img.shields.io/npm/v/@nextcloud/logger.svg)](https://www.npmjs.com/package/@nextcloud/logger)
+[![Documentation](https://img.shields.io/badge/Documentation-online-brightgreen)](https://nextcloud.github.io/nextcloud-logger/)
+
 Generic JavaScript logging interface for Nextcloud apps and libraries
 
 ## Usage
+See also [API documentation](https://nextcloud.github.io/nextcloud-logger/).
 
 ```js
 import { getLoggerBuilder } from '@nextcloud/logger'


### PR DESCRIPTION
There is no docs deployment since travis was dropped, so use a github workflow for deployment of the docs.
(similar as we do it on `nextcloud-l10n`).

Also added a link to it (and badges) to the README.