### PR TITLE
Add typings to published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "description": "",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -d && babel ./lib --out-dir dist --extensions '.ts,.tsx' --source-maps",
     "build:doc": "typedoc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,15 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "ESNext",
         "module": "commonjs",
         "declaration": true,
         "outDir": "./dist",
+        "declarationDir": "./dist",
         "strict": true,
         "lib": [
             "es6",
             "dom"
         ]
-    }
+    },
+    "include": [ "lib/*" ]
 }


### PR DESCRIPTION
* Resolves #375 (after new release)

Currently the package is missing the `types` entry point and typings are located in the wrong directory.