### PR TITLE
Only add required files to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
   "engines": {
     "node": "^16.0.0",
     "npm": "^7.0.0 || ^8.0.0"
-  }
+  },
+  "files": [
+    "dist/",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
Currently all files are included in the npm package, even the github workflows, the config files, the tests ...

This limits the included files to:
* The output (`dist/`)
* The read me
* The license (of cause)
* The changelog